### PR TITLE
Improve handling of binder auto profile swapping.

### DIFF
--- a/Binder.lua
+++ b/Binder.lua
@@ -64,11 +64,13 @@ function Binder_OnEvent(self, event, ...)
 		Minimap_Options_WhenLoaded();
 	elseif ( event == "ACTIVE_TALENT_GROUP_CHANGED" ) then
 		local currentSpec = GetSpecialization()
+		local class = select(2, UnitClass("player"))
 		if Current_Specialization ~= currentSpec then
 			local currentSpecName = currentSpec and select(2, GetSpecializationInfo(currentSpec)) or "None"
 			out_frame("Specialization changed to: " .. currentSpecName)
 			Current_Specialization = currentSpec
-			Load_Profile(currentSpecName)
+			out_frame("Trying to load profile: " .. class .. "-" .. currentSpecName)
+			Load_Profile(class .. "-" .. currentSpecName)
 		end
 	end
 end

--- a/Binder.lua
+++ b/Binder.lua
@@ -63,13 +63,38 @@ function Binder_OnEvent(self, event, ...)
 		Binder_MinimapButton_OnLoad();
 		Minimap_Options_WhenLoaded();
 	elseif ( event == "ACTIVE_TALENT_GROUP_CHANGED" ) then
+
 		local currentSpec = GetSpecialization()
+		local specProfileName = currentSpec and select(2, GetSpecializationInfo(currentSpec)) or "None"
+		local specProfileExists = false
+
 		local class = UnitClass("player")
+		local classSpecProfileName = class .. "-" .. specProfileName
+		local classSpecProfileExists = false 
+
+    	-- Look for the existence of a profile named "class-spec" and "spec".
+		for i = 1, Binder_Settings.ProfilesCreated do 
+			local profileName = Binder_Settings.Profiles[i].Name
+
+			if (profileName == classSpecProfileName) then
+				classSpecProfileExists = true
+			elseif (profileName == specProfileName) then
+				specProfileExists = true
+			end
+		end
+
 		if Current_Specialization ~= currentSpec then
-			local currentSpecName = currentSpec and select(2, GetSpecializationInfo(currentSpec)) or "None"
-			out_frame("Specialization changed to: " .. currentSpecName)
+			
+			out_frame("Specialization changed to: " .. specProfileName)
 			Current_Specialization = currentSpec
-			Load_Profile(class .. "-" .. currentSpecName)
+
+			-- Use a "class-spec" profile over "spec", do nothing if none exist.
+			if (classSpecProfileExists) then 
+				Load_Profile(classSpecProfileName)
+			elseif (specProfileExists) then
+				Load_Profile(specProfileName)
+			end
+
 		end
 	end
 end

--- a/Binder.lua
+++ b/Binder.lua
@@ -65,11 +65,11 @@ function Binder_OnEvent(self, event, ...)
 	elseif ( event == "ACTIVE_TALENT_GROUP_CHANGED" ) then
 
 		local currentSpec = GetSpecialization()
-		local specProfileName = currentSpec and select(2, GetSpecializationInfo(currentSpec)) or "None"
+		local specName = currentSpec and select(2, GetSpecializationInfo(currentSpec)) or "None"
 		local specProfileExists = false
 
 		local class = UnitClass("player")
-		local classSpecProfileName = class .. "-" .. specProfileName
+		local classSpecProfileName = class .. "-" .. specName
 		local classSpecProfileExists = false 
 
     	-- Look for the existence of a profile named "class-spec" and "spec".
@@ -78,21 +78,21 @@ function Binder_OnEvent(self, event, ...)
 
 			if (profileName == classSpecProfileName) then
 				classSpecProfileExists = true
-			elseif (profileName == specProfileName) then
+			elseif (profileName == specName) then
 				specProfileExists = true
 			end
 		end
 
 		if Current_Specialization ~= currentSpec then
 			
-			out_frame("Specialization changed to: " .. specProfileName)
+			out_frame("Specialization changed to: " .. specName)
 			Current_Specialization = currentSpec
 
 			-- Use a "class-spec" profile over "spec", do nothing if none exist.
 			if (classSpecProfileExists) then 
 				Load_Profile(classSpecProfileName)
 			elseif (specProfileExists) then
-				Load_Profile(specProfileName)
+				Load_Profile(specName)
 			end
 
 		end

--- a/Binder.lua
+++ b/Binder.lua
@@ -64,12 +64,11 @@ function Binder_OnEvent(self, event, ...)
 		Minimap_Options_WhenLoaded();
 	elseif ( event == "ACTIVE_TALENT_GROUP_CHANGED" ) then
 		local currentSpec = GetSpecialization()
-		local class = select(2, UnitClass("player"))
+		local class = UnitClass("player")
 		if Current_Specialization ~= currentSpec then
 			local currentSpecName = currentSpec and select(2, GetSpecializationInfo(currentSpec)) or "None"
 			out_frame("Specialization changed to: " .. currentSpecName)
 			Current_Specialization = currentSpec
-			out_frame("Trying to load profile: " .. class .. "-" .. currentSpecName)
 			Load_Profile(class .. "-" .. currentSpecName)
 		end
 	end


### PR DESCRIPTION
Hi,

I've been wanting this feature for a while. Decided to just have a go adding it, was very simple in the end. Maybe you want to incorporate it to the addon. 

Basically just makes the automatically Load_Profile on spec swap look for a profile called class-spec rather than just spec. Fixes the problem if you play two identically named specs like holy priest/pala or resto druid/shaman but want to have seperate keybindings for each. 

Thanks,
Alex