### PR TITLE
Add packaging workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Package and release
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Package and release
+        uses: BigWigsMods/packager@v2


### PR DESCRIPTION
Hi,

First of all, thank you for your addon, it is one of my must-have addons.

Since I use WowUp and your addon is not available on any of the addons publishers allowing WowUp, I wanted to help you with making your addon available for installation by using the repository URL.

This pull request simply adds a workflow which packages a `.zip` archive every time a new tag is pushed on the repo. This way, WowUp users can easily install your addon without having to use Curse if they don't want to.

Let me know if you need anything more for this PR.

Best regards